### PR TITLE
feat: param lookup annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,14 +8,14 @@ Define routes using the `@Route` decorator, and plain javascript classes.
 ## Route Definition
 
 ```javascript
-import { Route } from '@ingress/router'
+import { Route, Param } from '@ingress/router'
 
 @Route('prefix')
 export class MyController {
 
   @Route.Get('/echo/:echo')
-  someRouteHandler ({ params }) {
-    return 'Echoing ' + params.echo
+  someRouteHandler (@Param.Path('echo') echo) {
+    return 'Echoing ' + echo
   }
 }
 // GET /prefix/echo/something ===> something

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   "scripts": {
     "build": "rm -rf lib && tsc --declaration",
     "test": "npm run lint && cross-env TS_NODE_IGNORE_WARNINGS=2304 mocha",
+    "mocha": "mocha",
     "prepublish": "npm run build && npm test",
     "lint": "tslint 'src/**/*.ts'"
   },
@@ -45,7 +46,7 @@
   },
   "dependencies": {
     "app-builder": "^5.1.0",
-    "reflect-annotations": "^2.0.0",
+    "reflect-annotations": "^2.2.0",
     "route-recognizer": "^0.2.9",
     "subtext": "^4.4.0"
   }

--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -1,4 +1,5 @@
 import { createAnnotationFactory } from 'reflect-annotations'
+import { RouterContext } from './context'
 
 const trim = (x: string) => x.replace(/^\/+|\/+$/g, ''),
   result = (x: string) => '/' + trim(x),
@@ -65,3 +66,44 @@ export const Route = <Route>methods.reduce((set, method) => {
   set[method].toString = () => method
   return set
 }, <any>createAnnotationFactory(RouteAnnotation))
+
+export interface ParamAnnotation {
+  extractValue(context: RouterContext<any>): any
+}
+
+class BodyParamAnnotation implements ParamAnnotation {
+  extractValue(context: RouterContext<any>) {
+    return context.req.body
+  }
+}
+
+class PathParamAnnotation implements ParamAnnotation {
+  constructor(private paramName: string) {}
+
+  extractValue(context: RouterContext<any>) {
+    return context.req.params[this.paramName]
+  }
+}
+
+class QueryParamAnnotation implements ParamAnnotation {
+  constructor(private paramName: string) {}
+
+  extractValue(context: RouterContext<any>) {
+    return context.req.query[this.paramName]
+  }
+}
+
+class HeaderParamAnnotation implements ParamAnnotation {
+  constructor(private paramName: string) {}
+
+  extractValue(context: RouterContext<any>) {
+    return context.req.headers[this.paramName]
+  }
+}
+
+export const Param = {
+  Body: createAnnotationFactory(BodyParamAnnotation),
+  Path: createAnnotationFactory(PathParamAnnotation),
+  Query: createAnnotationFactory(QueryParamAnnotation),
+  Header: createAnnotationFactory(HeaderParamAnnotation)
+}

--- a/src/body-parser.ts
+++ b/src/body-parser.ts
@@ -1,21 +1,24 @@
 import { parse } from 'subtext'
 import { createAnnotationFactory } from 'reflect-annotations'
+import { Annotation } from './annotations'
+
+export interface ParseBodyOptions {
+  parse: boolean,
+  output: 'data' | 'stream' | 'file',
+  maxBytes?: number,
+  override?: string,
+  defaultContentType?: string,
+  allow?: string,
+  timeout?: number
+  qs?: Object,
+  uploads?: string,
+  decoders?: { [key: string]: Function },
+  compression?: { [key: string]: Function }
+}
 
 export class ParseBodyAnnotation {
   public isBodyParser = true
-  constructor (public options:{
-      parse: boolean,
-      output: 'data' | 'stream' | 'file',
-      maxBytes?: number,
-      override?: string,
-      defaultContentType?: string,
-      allow?: string,
-      timeout?: number
-      qs?: Object,
-      uploads?: string,
-      decoders?: { [key: string]: Function },
-      compression?: { [key: string]: Function }
-    } = { parse: true, output: 'data', maxBytes: 1e7 }) {}
+  constructor (public options:ParseBodyOptions = { parse: true, output: 'data', maxBytes: 1e7 }) {}
 
   get middleware() {
     const options = this.options
@@ -34,6 +37,6 @@ export class ParseBodyAnnotation {
   }
 }
 
-export const ParseBody = createAnnotationFactory(ParseBodyAnnotation)
+export const ParseBody: (options?: ParseBodyOptions) => Annotation = createAnnotationFactory(ParseBodyAnnotation)
 
 export const parseJsonBody = new ParseBodyAnnotation().middleware

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -6,7 +6,7 @@ export interface ControllerOptions {
 }
 
 export interface Controller {
-  (options?: ControllerOptions): ClassDecorator
+  (options?: ControllerOptions | string): ClassDecorator
 }
 
 export type ControllerDecorator = Controller & ClassDecorator
@@ -19,7 +19,7 @@ export class ControllerCollector {
     this._collector = (target: any) => {
       this.collected.push(target)
     }
-    this.collect = (options?: ControllerOptions | any) => {
+    this.collect = ((options?: ControllerOptions | any) => {
       if (!options) {
         return this._collector
       }
@@ -31,7 +31,6 @@ export class ControllerCollector {
         }) as ClassDecorator
       }
       return this._collector(options) as ClassDecorator
-    }
-
+    }) as ControllerDecorator
   }
 }

--- a/test/annotations.spec.ts
+++ b/test/annotations.spec.ts
@@ -1,4 +1,4 @@
-import { RouteAnnotation, Route} from '../src/annotations'
+import { RouteAnnotation, Route } from '../src/annotations'
 import { expect } from 'chai'
 
 describe('Route annotations', () => {

--- a/test/router.spec.ts
+++ b/test/router.spec.ts
@@ -7,11 +7,12 @@ import {
   Route,
   Router,
   BaseRouterContext,
-  ParseBody
+  ParseBody,
+  Param
 } from '../src'
 
 const getAsync = (url:string) => get(`http://localhost:8888${url}`),
-  postAsync = (url: string, payload: any) => post(`http://localhost:8888${url}`, payload)
+  postAsync = (url: string, payload: any, headers?: any) => post(`http://localhost:8888${url}`, payload, headers)
 let expectedBody: any, expectedQuery: any, expectedParams: any, expectedResponse: any, router: any = null
 
 class MyContext extends BaseRouterContext<MyContext> {}
@@ -85,6 +86,34 @@ describe('Routing', () => {
         return null
       }
     }
+
+    @Controller('param-lookup')
+    class ParamLookup {
+      @Route.Post('body-lookup')
+      bodyParamLookup (@Param.Body() data: any) {
+        return data
+      }
+
+      @Route.Get('path-param-lookup/:id')
+      pathParamLookup (@Param.Path('id') id: string) {
+        return id
+      }
+
+      @Route.Get('query-param-lookup')
+      queryParamLookup (@Param.Query('value') value: string) {
+        return value
+      }
+
+      @Route.Post('header-lookup')
+      headerLookup (@Param.Body() body: string, @Param.Header('some-header') value: number) {
+        return body + ' ' + value
+      }
+
+      @Route.Get('default-lookup/:a/:b')
+      defaultRequestLookup ({ params: { a } }: any, @Param.Path('b') b: string) {
+        return a + ' ' + b
+      }
+    }
     server.use(router)
     return server.listen(8888)
   })
@@ -135,7 +164,7 @@ describe('Routing', () => {
   })
 
   it('should parse the body, query and route parameters', async () => {
-    expectedQuery = { a: 'b', b: 'c'}
+    expectedQuery = { a: 'b', b: 'c' }
     expectedParams = { a: '1', b: '2', c: '3' }
     expectedBody = { hello: 'world' }
 
@@ -150,6 +179,38 @@ describe('Routing', () => {
   it('should allow a custom body parser', () => {
     return postAsync('/api/test-buffer', { 'data': 'asdf' }).then(() => {
       sinon.assert.calledOnce(routeSpy)
+    })
+  })
+
+  describe('parameter lookup', () => {
+    it('should look up a body param', () => {
+      return postAsync('/api/param-lookup/body-lookup', 'content').then((res) => {
+        expect(res).to.eql('content')
+      })
+    })
+
+    it('should look up a path param', () => {
+      return getAsync('/api/param-lookup/path-param-lookup/42').then((res) => {
+        expect(res).to.eql('42')
+      })
+    })
+
+    it('should look up a query param', () => {
+      return getAsync('/api/param-lookup/query-param-lookup?value=42').then((res) => {
+        expect(res).to.eql('42')
+      })
+    })
+
+    it('should look up a header', () => {
+      return postAsync('/api/param-lookup/header-lookup', 'body-contents', { 'some-header': '42' }).then((res) => {
+        expect(res).to.eql('body-contents 42')
+      })
+    })
+
+    it('should supply the request by default', () => {
+      return getAsync('/api/param-lookup/default-lookup/asdf/foo').then((res) => {
+        expect(res).to.eql('asdf foo')
+      })
     })
   })
 })

--- a/test/util/http.ts
+++ b/test/util/http.ts
@@ -24,7 +24,7 @@ function parseResponse (response: any): Promise<string> {
   })
 }
 
-export function postAsync (path: string, data: any) {
+export function postAsync (path: string, data: any, headers: any = {}) {
   const url = parse(path),
     postData = data ? JSON.stringify(data) : '',
     options = {
@@ -34,7 +34,8 @@ export function postAsync (path: string, data: any) {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'Content-Length': Buffer.byteLength(postData)
+        'Content-Length': Buffer.byteLength(postData),
+        ...headers
       }
     }
 


### PR DESCRIPTION
Allows handler params to be looked up via annotations. Custom annotations could also be provided to extract various parts of the request.