### PR TITLE
allow body params to be looked up by key

### DIFF
--- a/src/annotations.ts
+++ b/src/annotations.ts
@@ -44,7 +44,7 @@ class RouteAnnotation {
   }
 }
 
-export type Annotation = ClassDecorator & MethodDecorator
+export type Annotation = ClassDecorator & MethodDecorator & ParameterDecorator
 
 export interface PathFactory {
   (urlDefinition?: string, ...methods: Array<PathFactory|string>): Annotation
@@ -73,8 +73,10 @@ export interface ParamAnnotation {
 }
 
 class BodyParamAnnotation implements ParamAnnotation {
+  constructor(private key?: string) {}
+
   extractValue(context: RouterContext<any>) {
-    return context.req.body
+    return this.key ? context.req.body && context.req.body[this.key] : context.req.body
   }
 }
 
@@ -103,7 +105,7 @@ class HeaderParamAnnotation implements ParamAnnotation {
 }
 
 const
-  Body = createAnnotationFactory(BodyParamAnnotation),
+  Body: (key?: string) => Annotation = createAnnotationFactory(BodyParamAnnotation),
   Path = createAnnotationFactory(PathParamAnnotation),
   Query = createAnnotationFactory(QueryParamAnnotation),
   Header = createAnnotationFactory(HeaderParamAnnotation),

--- a/test/router.spec.ts
+++ b/test/router.spec.ts
@@ -123,6 +123,11 @@ describe('Routing', () => {
         return data
       }
 
+      @Route.Post('body-key-lookup')
+      bodyParamKeyLookup (@Param.Body('key') data: any) {
+        return data
+      }
+
       @Route.Get('path-param-lookup/:id')
       pathParamLookup (@Param.Path('id') id: string) {
         return id
@@ -258,6 +263,18 @@ describe('Routing', () => {
     it('should look up a body param', () => {
       return postAsync('/api/param-lookup/body-lookup', 'content').then((res) => {
         expect(res).to.eql('content')
+      })
+    })
+
+    it('should look up a body param by key', () => {
+      return postAsync('/api/param-lookup/body-key-lookup', { key: 'content' }).then((res) => {
+        expect(res).to.eql('content')
+      })
+    })
+
+    it('should return undefined when looking up a key for a null body', () => {
+      return postAsync('/api/param-lookup/body-key-lookup', null).then((res) => {
+        expect(res).to.eql('OK')
       })
     })
 


### PR DESCRIPTION
allows body params to be specified using `@Param.Body('someKey')` which is a key pulled off of the body.